### PR TITLE
Added custom Markers on top of the google maps API.

### DIFF
--- a/frontend/src/pages/Map/Map.tsx
+++ b/frontend/src/pages/Map/Map.tsx
@@ -1,54 +1,97 @@
 import React, { useEffect, useState } from 'react';
 import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
 import { mapContainerStyle, center, zoom, options } from './settings';
+import ReportMarker, { ReportMarkerType } from './Markers';
 
-const Map: React.FC = () => {
+const Map: React.FC = () =>
+{
   // get api key
-  const [key, setKey] = useState<string>();
-  useEffect(() => {
-    async function getKey() {
-      const response = await fetch('/api/keys/map');
+  const [ key, setKey ] = useState<string>();
+  useEffect( () =>
+  {
+    async function getKey ()
+    {
+      const response = await fetch( '/api/keys/map' );
       const key = await response.text();
-      setKey(key);
+      setKey( key );
     }
 
     getKey();
-  }, []);
+  }, [] );
 
-  return key !== undefined ? <MapChild apiKey={key} /> : <div> Map Loading...</div>
+  return key !== undefined ? <MapChild apiKey={ key } /> : <div> Map Loading...</div>;
 };
 
-const MapChild: React.FC<{ apiKey: string }> = (props) => {
+const MapChild: React.FC<{ apiKey: string; }> = ( props ) =>
+{
+
+  /**********TEMPORARY MARKER DATA***********/
+
+  var baseLat = 29.639;
+  var baseLng = -82.360;
+
+  // generate the data || grab data from API
+  var tmpMarkers: Array<ReportMarkerType> = new Array<ReportMarkerType>();
+  for ( var i = 0; i < 10; i++ )
+  {
+    var tmpLatLng: google.maps.LatLngLiteral = {
+      lat: ( baseLat + ( 0.001 * i ) ),
+      lng: ( baseLng + ( 0.003 * i ) )
+    };
+    var tmpReportMarker: ReportMarkerType = {
+      id: String( i ),
+      location: tmpLatLng
+    };
+    tmpMarkers.push( tmpReportMarker );
+  }
+
+  // store data in a React Hook
+  const [ points ] = useState<Array<ReportMarkerType>>( tmpMarkers );
+
+  /******************************************/
+
+  /*************MAP RENDERING****************/
+
   // load the map
   const { isLoaded, loadError } = useJsApiLoader
-    ({
+    ( {
       id: 'google-map-ide',
       googleMapsApiKey: props.apiKey
-    });
+    } );
 
-  const renderMap = () => {
-    const onLoad = (_map: google.maps.Map): void => {
-      console.log("map loaded")
-    }
+  const renderMap = () =>
+  {
+    const onLoad = ( _map: google.maps.Map ): void =>
+    {
+      console.log( "map loaded" );
+    };
 
     return (
       <GoogleMap
-        mapContainerStyle={mapContainerStyle}
-        options={options as google.maps.MapOptions}
-        center={center}
-        zoom={zoom}
-        onLoad={onLoad}
+        mapContainerStyle={ mapContainerStyle }
+        options={ options as google.maps.MapOptions }
+        center={ center }
+        zoom={ zoom }
+        onLoad={ onLoad }
       >
-        {/* we can add the overlay here (just make sure to cache the components) */}
+        {
+          points?.map( point =>
+          (
+            <ReportMarker ReportMarkerStruct={ point } />
+          ) )
+        }
       </GoogleMap>
     );
+  };
+
+  if ( loadError )
+  {
+    return <div>Map cannot be loaded right now, sorry.</div>;
   }
 
-  if (loadError) {
-    return <div>Map cannot be loaded right now, sorry.</div>
-  }
+  return isLoaded ? renderMap() : <div> Map Loading...</div>;
 
-  return isLoaded ? renderMap() : <div> Map Loading...</div>
-}
+  /******************************************/
+};
 
 export default Map;

--- a/frontend/src/pages/Map/Markers.tsx
+++ b/frontend/src/pages/Map/Markers.tsx
@@ -1,0 +1,29 @@
+import { MarkerF } from '@react-google-maps/api';
+import ReportMarkerIcon from './images/map-pin.svg';
+
+// a struct representing required marker values
+export type ReportMarkerType = {
+  id: string;
+  location: google.maps.LatLngLiteral;
+};
+
+// onClick event handler
+const onClickReportMarker = ( marker: ReportMarkerType ) => console.log( "clicked" ); // this needs to be chagned to bring up details about the report
+
+// React FC for rendering Markers from a Marker Struct
+const ReportMarker: React.FC<{ ReportMarkerStruct: ReportMarkerType; }> = props =>
+{
+  return <MarkerF
+    key={ props.ReportMarkerStruct.id }
+    position={ props.ReportMarkerStruct.location }
+    onClick={ () => onClickReportMarker( props.ReportMarkerStruct ) }
+    icon={ {
+      url: ReportMarkerIcon,
+      origin: new window.google.maps.Point( 0, 0 ),
+      anchor: new window.google.maps.Point( 15, 15 ),
+      scaledSize: new window.google.maps.Size( 30, 30 )
+    } }
+  />;
+};
+
+export default ReportMarker;

--- a/frontend/src/pages/Map/images/map-pin.svg
+++ b/frontend/src/pages/Map/images/map-pin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-map-pin" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <title>Layer 1</title>
+  <path fill="#e53446" id="svg_3" d="m17.657,16.657l-4.243,4.243a2,2 0 0 1 -2.827,0l-4.244,-4.243a8,8 0 1 1 11.314,0z"/>
+  <circle id="svg_2" r="3" cy="11" cx="12"/>
+</svg>

--- a/frontend/src/pages/Map/mapStylesheet.ts
+++ b/frontend/src/pages/Map/mapStylesheet.ts
@@ -1,6 +1,6 @@
 
 /*
-  JSON stylesheet for the goole map
+  JSON stylesheet for the google map
 
   LINK TO DOCUMENTATION
   https://developers.google.com/maps/documentation/javascript/style-reference


### PR DESCRIPTION
A separate wrapper class called ReportMarker was made so that they can be rendered on top of the google maps API. The ReportMarker FC takes in a ReportMarkerType type struct and generates a MarkerF react-google-maps/api component from it to render back to the screen. 